### PR TITLE
docs: add API README use guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -871,6 +871,20 @@ normal certificate validation.
 They pass auth decisions and tokens per call, which makes APIs noisy and harder
 to configure safely. Use `IApiClient` with config/auth providers instead.
 
+## Validation
+
+Run the shared package validator from this repository root:
+
+```powershell
+python C:/Repositories/Package-Registry/Tools/deucarian_package_validator.py --registry-root C:/Repositories/Package-Registry --repository-root . --config deucarian-package.json
+```
+
+Documentation-only updates should still pass:
+
+```powershell
+git diff --check
+```
+
 ## Documentation Maintenance Policy
 
 Documentation must be updated whenever public APIs are added, changed,
@@ -887,3 +901,7 @@ deprecated, or removed. This includes:
 - [AGENTS.md](AGENTS.md) contains repository-specific ownership and Codex guidance.
 - Deucarian architecture rules live in [Package Registry](https://github.com/Deucarian/Package-Registry/blob/develop/ARCHITECTURE.md).
 - Capability ownership is tracked in [CAPABILITY_OWNERSHIP.md](https://github.com/Deucarian/Package-Registry/blob/develop/CAPABILITY_OWNERSHIP.md).
+
+## License
+
+MIT. See `LICENSE.md`.

--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ requests.
 
 Package ID: `com.deucarian.api`
 
+## When To Use This
+
+Use this package when a Unity project needs reusable HTTP/API transport, request building, response parsing, JSON/text/byte/texture responses, ScriptableObject endpoint configuration, authentication providers, cancellation-aware calls, and Deucarian Logging-backed API diagnostics.
+
+Do not use this package to own session lifecycle, object-loading source resolution, package installation, gameplay runtime behavior, or Unity object lifetime cleanup. Those capabilities belong to their owning Deucarian packages.
+
 ## Core Concepts
 
 - `IApiClient` as the main injectable dependency.


### PR DESCRIPTION
## Summary
- Add explicit API README guidance for when to use the package and which capabilities remain owned by Session, Object Loading, Package Installer, gameplay packages, and Common.
- Add explicit README validation and license footer sections.

## Validation
- `python C:/Repositories/Package-Registry/Tools/deucarian_package_validator.py --registry-root C:/Repositories/Package-Registry --repository-root . --config deucarian-package.json`
- `git diff --check`
- `git diff --cached --check`